### PR TITLE
Update the instance of RDS

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -326,7 +326,7 @@ func NewNetworkV2Client() (*gophercloud.ServiceClient, error) {
 // NewRdsV1Client returns a *ServiceClient for making calls to the
 // OpenStack RDS v1 API. An error will be returned if authentication
 // or client creation was not possible.
-func NewRdsV1Client() (*gophercloud.ServiceClient1, error) {
+func NewRdsV1Client() (*gophercloud.ServiceClient, error) {
 	ao, err := openstack.AuthOptionsFromEnv()
 	if err != nil {
 		return nil, err

--- a/acceptance/openstack/rds/v1/instance.go
+++ b/acceptance/openstack/rds/v1/instance.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CreateRdsinstance creates a basic Rds instance with a randomly generated name.
-func CreateRdsInstance(t *testing.T, client *gophercloud.ServiceClient1,
+func CreateRdsInstance(t *testing.T, client *gophercloud.ServiceClient,
     routerId string, networkId string, securityGroupId string) (*instances.Instance, error) {
 	if testing.Short() {
 		t.Skip("Skipping test that requires Rds instance creation in short mode.")
@@ -81,7 +81,7 @@ func CreateRdsInstance(t *testing.T, client *gophercloud.ServiceClient1,
 
 // WaitForInstanceStatus will poll an rds instance's status until it either matches
 // the specified status or the status becomes ERROR.
-func WaitForInstanceStatus(t *testing.T, client *gophercloud.ServiceClient1, id string, status string) error {
+func WaitForInstanceStatus(t *testing.T, client *gophercloud.ServiceClient, id string, status string) error {
     return WaitStatusFor(func() (bool, error) {
         latest, err := instances.Get(client, id).Extract()
         if err != nil {
@@ -105,7 +105,7 @@ func WaitForInstanceStatus(t *testing.T, client *gophercloud.ServiceClient1, id 
 }
 
 
-func WaitForInstanceVolumeSize(t *testing.T, client *gophercloud.ServiceClient1, id string, volumeSize int) error {
+func WaitForInstanceVolumeSize(t *testing.T, client *gophercloud.ServiceClient, id string, volumeSize int) error {
     return WaitStatusFor(func() (bool, error) {
         latest, err := instances.Get(client, id).Extract()
         if err != nil {
@@ -140,7 +140,7 @@ func WaitStatusFor(predicate func() (bool, error)) error {
 }
 
 
-func UpdateRdsInstance(t *testing.T, client *gophercloud.ServiceClient1, id string,
+func UpdateRdsInstance(t *testing.T, client *gophercloud.ServiceClient, id string,
     volumeSize int) (*instances.Instance, error) {
     if testing.Short() {
         t.Skip("Skipping test that requires Rds instance creation in short mode.")
@@ -169,7 +169,7 @@ func UpdateRdsInstance(t *testing.T, client *gophercloud.ServiceClient1, id stri
 
 
 // DeleteRdsInstance deletes an instance via its UUID.
-func DeleteRdsInstance(t *testing.T, client *gophercloud.ServiceClient1, instance *instances.Instance) {
+func DeleteRdsInstance(t *testing.T, client *gophercloud.ServiceClient, instance *instances.Instance) {
     result := instances.Delete(client, instance.ID)
     if result.Err != nil {
         t.Fatalf("Unable to delete Rds instance %s: %s", instance.ID, result.Err)

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -415,8 +415,11 @@ func NewSmnServiceV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoint
 
 //NewRdsServiceV1 creates the a ServiceClient that may be used to access the v1
 //rds service which is a service of db instances management.
-func NewRdsServiceV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient1, error) {
-	sc, err := initClientOpts1(client, eo, "rds")
-	sc.ResourceBase = sc.Endpoint + sc.ProjectID +"/"
-	return sc, err
+func NewRdsServiceV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	newsc, err := initClientOpts(client, eo, "compute")
+	rdsendpoint := strings.Replace(strings.Replace(newsc.Endpoint, "ecs", "rds", 1), "/v2/", "/rds/v1/", 1)
+	newsc.Endpoint = rdsendpoint
+	newsc.ResourceBase = rdsendpoint
+	newsc.Type = "rds"
+	return newsc, err
 }

--- a/openstack/rds/v1/datastores/requests.go
+++ b/openstack/rds/v1/datastores/requests.go
@@ -9,7 +9,7 @@ var RequestOpts gophercloud.RequestOpts = gophercloud.RequestOpts{
 }
 
 //list the version informations about a specified type of database
-func List(client *gophercloud.ServiceClient1, dataStoreName string) (r ListResult) {
+func List(client *gophercloud.ServiceClient, dataStoreName string) (r ListResult) {
 
 	_, r.Err = client.Get(listURL(client, dataStoreName), &r.Body, &gophercloud.RequestOpts{
 		OkCodes:     []int{200},

--- a/openstack/rds/v1/datastores/urls.go
+++ b/openstack/rds/v1/datastores/urls.go
@@ -2,6 +2,6 @@ package datastores
 
 import "github.com/gophercloud/gophercloud"
 
-func listURL(c *gophercloud.ServiceClient1, dataStoreName string) string {
+func listURL(c *gophercloud.ServiceClient, dataStoreName string) string {
 	return c.ServiceURL("datastores", dataStoreName, "versions")
 }

--- a/openstack/rds/v1/flavors/requests.go
+++ b/openstack/rds/v1/flavors/requests.go
@@ -9,7 +9,7 @@ var RequestOpts gophercloud.RequestOpts = gophercloud.RequestOpts{
 }
 
 //list the flavors informations about a specified id of database
-func List(client *gophercloud.ServiceClient1, dataStoreID string, region string) (r ListResult) {
+func List(client *gophercloud.ServiceClient, dataStoreID string, region string) (r ListResult) {
 
 	_, r.Err = client.Get(listURL(client, dataStoreID, region), &r.Body, &gophercloud.RequestOpts{
 		OkCodes:     []int{200},

--- a/openstack/rds/v1/flavors/urls.go
+++ b/openstack/rds/v1/flavors/urls.go
@@ -2,7 +2,7 @@ package flavors
 
 import "github.com/gophercloud/gophercloud"
 
-func listURL(c *gophercloud.ServiceClient1, dataStoreID string, region string) string {
+func listURL(c *gophercloud.ServiceClient, dataStoreID string, region string) string {
 
 	return c.ResourceBaseURL() + "flavors?dbId=" + dataStoreID + "&region=" + region
 }

--- a/openstack/rds/v1/instances/urls.go
+++ b/openstack/rds/v1/instances/urls.go
@@ -2,22 +2,26 @@ package instances
 
 import "github.com/gophercloud/gophercloud"
 
-func createURL(c *gophercloud.ServiceClient1) string {
+func createURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func deleteURL(c *gophercloud.ServiceClient1, id string) string {
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("instances", id)
 }
 
-func getURL(c *gophercloud.ServiceClient1, id string) string {
+func getURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("instances", id)
 }
 
-func listURL(c *gophercloud.ServiceClient1) string {
+func listURL(c *gophercloud.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func updateURL(c *gophercloud.ServiceClient1, id string) string {
+func updateURL(c *gophercloud.ServiceClient, id string) string {
 	return c.ServiceURL("instances", id, "action")
+}
+
+func updatePolicyURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("instances", id, "backups/policy")
 }


### PR DESCRIPTION
This PR updates the instance of RDS.

Sometimes calling get token API to get the project id in the method getV3ProjectId may return nil in my test environment.
So it will use gophercloud.ServiceClient in the RDS client instead. 

Thie link shows the acceptance tests result about his PR[1].

[1], http://paste.openstack.org/show/640185/