### PR TITLE
Add schedule hint support

### DIFF
--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -39,13 +39,17 @@ type CreateOpts struct {
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
         // The schedule parameters
-        ScheduleHint map[string]string `json:"OS-SCH-HNT:scheduler_hints,omitempty"`
+        SchedulerHints map[string]string `json:"-"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a
 // CreateOpts.
 func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "volume")
+	m, err := gophercloud.BuildRequestBody(opts, "volume")
+	if len(opts.SchedulerHints) > 0 {
+		m["OS-SCH-HNT:scheduler_hints"] = opts.SchedulerHints
+	}
+	return m, err
 }
 
 // Create will create a new Volume based on the values in CreateOpts. To extract

--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -38,6 +38,8 @@ type CreateOpts struct {
 	ImageID string `json:"imageRef,omitempty"`
 	// The associated volume type
 	VolumeType string `json:"volume_type,omitempty"`
+        // The schedule parameters
+        ScheduleHint map[string]string `json:"OS-SCH-HNT:scheduler_hints,omitempty"`
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a


### PR DESCRIPTION
Add schedule hint support

**Use Case**
The OpenStack cinder supports to add schedule parameters when creating 
volume, the name of the parameters in API doc is "OS-SCH-HNT:scheduler_hints" 
that can be found in Cinder API document [here](https://developer.openstack.org/api-ref/block-storage/v3/index.html#volumes-volumes)
In some cases, the user wish to set the parameters to fix the volume location.
this PR is to propose to add this parameter support in otc provider.

**Changes To Proposal**
In order to support this paramter, these parties need to change:
1. Add the parameter support in volume CreateOpts of volume

Resolves: #7